### PR TITLE
Fixing duplicate id issue for mount.path

### DIFF
--- a/nfs/client.sls
+++ b/nfs/client.sls
@@ -14,8 +14,9 @@ nfs_client_packages:
   - require:
     - pkg: nfs_client_packages
 
-{{ mount.path }}:
+{{ mount.path|replace("/","_") }}_mount:
   mount.mounted:
+    - name: {{ mount.path }}
     - device: {{ mount.device }}
     - fstype: {{ mount.fstype }}
     - require:

--- a/nfs/client.sls
+++ b/nfs/client.sls
@@ -14,7 +14,7 @@ nfs_client_packages:
   - require:
     - pkg: nfs_client_packages
 
-{{ mount.path|replace("/","_") }}_mount:
+{{ mount.path|replace("/","_") }}_nfs_mount:
   mount.mounted:
     - name: {{ mount.path }}
     - device: {{ mount.device }}


### PR DESCRIPTION
It is dangerous to use {{ mount.path }} as a resource id as it may duplicate defined one.

Example:
Detected conflicting IDs, SLS IDs need to be globally unique.
The conflicting ID is '/var/lib/glance/images' and is found in SLS 'base:glance.server' and SLS 'base:nfs.client'

This patch fixes that issue.